### PR TITLE
added few resources for further work on porting for cases

### DIFF
--- a/retro-home-image
+++ b/retro-home-image
@@ -605,16 +605,19 @@ case "${REMIX}" in
         echo "[+] Specified Rasberry Pi 2, 3, 4 or 400"
         shift;;
     gamehat)
+        #https://www.waveshare.com/wiki/Game_HAT
         SKIP_DESKTOP=1
         echo "[+] Specified Waveshare Game HAT"
         not_implemented
         shift;;
     gamepi20)
+        #https://www.waveshare.com/wiki/GamePi20
         SKIP_DESKTOP=1
         echo "[+] Specified Waveshare GamePi20"
         not_implemented
         shift;;
     gamepi43)
+        #https://www.waveshare.com/wiki/GamePi43
         SKIP_DESKTOP=1
         echo "[+] Specified Waveshare GamePi43"
         not_implemented
@@ -638,6 +641,7 @@ case "${REMIX}" in
         REMIX="gpimateplus"
         shift;;
     gpm280)
+        #https://www.waveshare.com/wiki/GPM280
         SKIP_DESKTOP=1
         echo "[+] Specified Waveshare GPM280"
         not_implemented
@@ -658,6 +662,8 @@ case "${REMIX}" in
         REMIX="megabit"
         shift;;
     monster)
+        #https://github.com/RetroPie/RetroPie-Setup/blob/master/scriptmodules/supplementary/snesdev.sh
+        #V1 and V2 differs this needs to be setup on first boot
         echo "[+] Specified Monster Arcade Controller Kit"
         not_implemented
         shift;;
@@ -666,10 +672,12 @@ case "${REMIX}" in
         REMIX="retroflag"
         shift;;
     picade)
+        #https://get.pimoroni.com/picadehat
         echo "[+] Specified Pimoroni Picade"
         not_implemented
         shift;;
     picadeconsole)
+        ##https://get.pimoroni.com/picadehat
         echo "[+] Specified Pimoroni Picade Console"
         not_implemented
         shift;;
@@ -678,8 +686,9 @@ case "${REMIX}" in
         REMIX="retroflag"
         shift;;
     pistationlcd)
+        #same as retroflag LCD attaches to first microHDMI and connects to USB-C power
         echo "[+] Specified RetroFlag PiStation Case with LCD"
-        not_implemented
+        REMIX="retroflag"
         shift;;
     superpi)
         echo "[+] Specified RetroFlag SUPERPi Case"


### PR DESCRIPTION
Picadehat has an installer for both board as the one with the screen is a builtin screen with HDMI connection 
`https://get.pimoroni.com/picadehat`
Monster arcade is a bit more complicated as it has two version and both has installer in retropie for first start with the module called snesdev
`https://github.com/RetroPie/RetroPie-Setup/blob/master/scriptmodules/supplementary/snesdev.sh`

And I took the liberty and added PS1 case with the screen to the retroflag mix as the screen attaches to microHDMI and USB-C which makes it the same software wise as the original case.

Waweshare boot configs will be bit complicated as all of them has different layouts, but all documented and only has their own config.txt and dtdo file.